### PR TITLE
Add five styles to `Style`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,0 +1,11 @@
+# Changelog for rio-prettyprint
+
+## 0.1.1.0
+
+* Add `Debug`, `Info` and `OtherLevel` data constructors to type `Style` (intended to be used like the existing `Warning` and `Error` constructors) and a `logLevelToStyle` function.
+* Add `Secondary` and `Highlight` data constructors to type `Style`.
+* `defaultStyles` now includes defaults for the new `Style` values, corresponding to those used by the `rio` package in its logging output.
+
+## 0.1.0.0
+
+* Initial stable release

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:        rio-prettyprint
-version:     0.1.0.0
+version:     0.1.1.0
 synopsis:    Pretty-printing for RIO
 category:    Development
 author:      Michael Snoyman

--- a/src/RIO/PrettyPrint.hs
+++ b/src/RIO/PrettyPrint.hs
@@ -18,6 +18,7 @@ module RIO.PrettyPrint
       -- to provide consistency.
     , style
     , displayMilliseconds
+    , logLevelToStyle
       -- * Formatting utils
     , bulletedList
     , spacedBulletedList
@@ -174,3 +175,14 @@ bulletedList = mconcat . intersperse line . map (("*" <+>) . align)
 -- each.
 spacedBulletedList :: [StyleDoc] -> StyleDoc
 spacedBulletedList = mconcat . intersperse (line <> line) . map (("*" <+>) . align)
+
+-- | The 'Style' intended to be associated with a 'LogLevel'.
+--
+-- @since 0.1.1.0
+logLevelToStyle :: LogLevel -> Style
+logLevelToStyle level = case level of
+  LevelDebug   -> Debug
+  LevelInfo    -> Info
+  LevelWarn    -> Warning
+  LevelError   -> Error
+  LevelOther _ -> OtherLevel

--- a/src/RIO/PrettyPrint/DefaultStyles.hs
+++ b/src/RIO/PrettyPrint/DefaultStyles.hs
@@ -17,6 +17,9 @@ defaultStyles :: Styles
 defaultStyles = array (minBound, maxBound)
   [ (Error, ("error", [SetColor Foreground Vivid Red]))
   , (Warning, ("warning", [SetColor Foreground Dull Yellow]))
+  , (Info, ("info", [SetColor Foreground Dull Blue]))
+  , (Debug, ("debug", [SetColor Foreground Dull Green]))
+  , (OtherLevel, ("other-level", [SetColor Foreground Dull Magenta]))
   , (Good, ("good", [SetColor Foreground Vivid Green]))
   , (Shell, ("shell", [SetColor Foreground Vivid Magenta]))
   , (File, ("file", [SetColor Foreground Dull Cyan]))
@@ -30,4 +33,7 @@ defaultStyles = array (minBound, maxBound)
   , (Target, ("target", [SetColor Foreground Vivid Cyan]))
   -- TODO: what color should Module be?
   , (Module, ("module", [SetColor Foreground Vivid Magenta]))
-  , (PkgComponent, ("package-component", [SetColor Foreground Vivid Cyan])) ]
+  , (PkgComponent, ("package-component", [SetColor Foreground Vivid Cyan]))
+  , (Secondary, ("secondary", [SetColor Foreground Vivid Black]))
+  , (Highlight, ("highlight", [SetColor Foreground Vivid Green]))
+  ]

--- a/src/RIO/PrettyPrint/Types.hs
+++ b/src/RIO/PrettyPrint/Types.hs
@@ -20,27 +20,42 @@ import System.Console.ANSI.Types (SGR)
 
 -- |A style of rio-prettyprint's output.
 data Style
-  = Error    -- Should be used sparingly, not to style entire long messages. For
-             -- example, it's used to style the "Error:" label for an error
-             -- message, not the entire message.
-  | Warning  -- Should be used sparingly, not to style entire long messages. For
-             -- example, it's used to style the "Warning:" label for an error
-             -- message, not the entire message.
-  | Good     -- Style in a way to emphasize that it is a particularly good
-             -- thing
-  | Shell    -- Style as a shell command, i.e. when suggesting something to the
-             -- user that should be typed in directly as written.
-  | File     -- Style as a filename. See 'Dir' for directories.
-  | Url      -- Style as a URL.
-  | Dir      -- Style as a directory name. See 'File' for files.
+  = Error     -- Should be used sparingly, not to style entire long messages.
+              -- For example, it's used to style the "Error:" or "[error]" label
+              -- for an error message, not the entire message.
+  | Warning   -- Should be used sparingly, not to style entire long messages.
+              -- For example, it's used to style the "Warning:" or "[warn]"
+              -- label for a warning message, not the entire message.
+  | Info      -- Should be used sparingly, not to style entire long messages.
+              -- For example, it's used to style the "[info]" label for an info
+              -- message, not the entire message.
+  | Debug     -- Should be used sparingly, not to style entire long messages.
+              -- For example, it's used to style the "[debug]" label for a debug
+              -- message, not the entire message.
+  | OtherLevel      -- Should be used sparingly, not to style entire long
+                    -- messages. For example, it's used to style the "[...]"
+                    -- label for an other log level message, not the entire
+                    -- message.
+  | Good      -- Style in a way to emphasize that it is a particularly good
+              -- thing.
+  | Shell     -- Style as a shell command, i.e. when suggesting something to the
+              -- user that should be typed in directly as written.
+  | File      -- Style as a filename. See 'Dir' for directories.
+  | Url       -- Style as a URL.
+  | Dir       -- Style as a directory name. See 'File' for files.
   | Recommendation  -- Style used to highlight part of a recommended course of
                     -- action.
-  | Current  -- Style in a way that emphasizes that it is related to a current
-             -- thing. For example, could be used when talking about the current
-             -- package we're processing when outputting the name of it.
-  | Target   -- TODO: figure out how to describe this
-  | Module   -- Style as a module name
+  | Current   -- Style in a way that emphasizes that it is related to a current
+              -- thing. For example, could be used when talking about the current
+              -- package we're processing when outputting the name of it.
+  | Target    -- TODO: figure out how to describe this
+  | Module    -- Style as a module name.
   | PkgComponent    -- Style used to highlight the named component of a package.
+  | Secondary -- Style for secondary content. For example, it's used to style
+              -- timestamps.
+  | Highlight -- Should be used sparingly, not to style entire long messages.
+              -- For example, it's used to style the duration in a "Finished
+              -- process in ... ms" message.
   deriving (Bounded, Enum, Eq, Ix, Ord, Show)
 
 -- |The first style overrides the second.


### PR DESCRIPTION
Add styles `Info`, `Debug`, `OtherLevel`, `Secondary` and `Highlight` to type `Style`, that correspond to:

(1) constructors of `RIO.Prelude.Logger.LogLevel` not currently catered for, namely `LevelInfo`, `LevelDebug` and `LevelOther !Text`. These constructors determine styles (currently hard-coded) used by `RIO.Prelude.Logger.simpleLogFunc`; and

(2) styles (currently hard-coded) used by `RIO.Prelude.Logger.simpleLogFunc` (for timestamps and locs, treated as secondary content) and `RIO.Process.withProcessTimeLog` (to highlight process duration).

The defaults for the additons, in `RIO.PrettyPrint.DefaultStyles`, are the hard-coded styles used in `RIO.Prelude.Logger.simpleLogFunc` and `RIO.Process.withProcessTimeLog`.

The additions do not change the order of the existing constructors of `Style`.

Code documentation for the new styles is included and the code document for existing styles is extended or tidied-up.

The motivation for these changes is explained in https://github.com/commercialhaskell/rio/pull/222.