### PR TITLE
Use the LTS resolver, for GHC 8.6.5

### DIFF
--- a/.azure/azure-linux-template.yml
+++ b/.azure/azure-linux-template.yml
@@ -6,12 +6,15 @@ jobs:
     matrix:
       stack-def:
         BUILD: stack
-      stack-lts-12:
+      stack-ghc-8.4.4:
         BUILD: stack
-        ARGS: "--resolver lts-12"
-      stack-lts-13:
+        ARGS: "--stack-yaml stack-ghc-8.4.4.yaml"
+      stack-ghc-8.6.5:
         BUILD: stack
-        ARGS: "--resolver lts-13"
+        ARGS: "--stack-yaml stack-ghc-8.6.5.yaml"
+      nightly:
+        BUILD: stack
+        ARGS: "--resolver nightly"
       cabal-8.4.4:
         BUILD: cabal
         GHCVER: 8.4.4
@@ -20,9 +23,6 @@ jobs:
         BUILD: cabal
         GHCVER: 8.6.5
         CABALVER: 2.4
-      nightly:
-        BUILD: stack
-        ARGS: "--resolver nightly"
       style:
         BUILD: style
       pedantic:

--- a/.azure/azure-osx-template.yml
+++ b/.azure/azure-osx-template.yml
@@ -6,12 +6,12 @@ jobs:
     matrix:
       stack-def:
         BUILD: stack
-      stack-lts-13:
+      stack-ghc-8.4.4:
         BUILD: stack
-        ARGS: "--resolver lts-13"
-      stack-lts-12:
+        ARGS: "--stack-yaml stack-ghc-8.4.4.yaml"
+      stack-ghc-8.6.5:
         BUILD: stack
-        ARGS: "--resolver lts-12"
+        ARGS: "--stack-yaml stack-ghc-8.6.5.yaml"
       stack-nightly:
         BUILD: stack
         ARGS: "--resolver nightly"

--- a/.azure/azure-windows-template.yml
+++ b/.azure/azure-windows-template.yml
@@ -4,14 +4,16 @@ jobs:
     vmImage: ${{ parameters.vmImage }}
   strategy:
     matrix:
-      stack-def:
+# GHC 8.8.x below 8.8.4 excluded because broken on Windows 10 version 2004. See
+# https://downloads.haskell.org/~ghc/8.8.4/docs/html/users_guide/8.8.4-notes.html#highlights
+#     stack-def:
+#       BUILD: stack
+      stack-ghc-8.4.4:
         BUILD: stack
-      stack-lts-13:
+        ARGS: "--stack-yaml stack-ghc-8.4.4.yaml"
+      stack-ghc-8.6.5:
         BUILD: stack
-        ARGS: "--resolver lts-13"
-      stack-lts-12:
-        BUILD: stack
-        ARGS: "--resolver lts-12"
+        ARGS: "--stack-yaml stack-ghc-8.6.5.yaml"
       stack-nightly:
         BUILD: stack
         ARGS: "--resolver nightly"

--- a/stack-ghc-8.4.4.yaml
+++ b/stack-ghc-8.4.4.yaml
@@ -1,0 +1,4 @@
+# Last for GHC 8.4.x
+resolver: lts-12.14
+extra-deps:
+- ansi-terminal-0.10.3

--- a/stack-ghc-8.6.5.yaml
+++ b/stack-ghc-8.6.5.yaml
@@ -1,0 +1,2 @@
+# Last for GHC 8.6.x
+resolver: lts-14.27

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,2 @@
-resolver: nightly-2019-07-15
-
-extra-deps:
-- ansi-terminal-0.9
+# For GHC 8.8.3 (none for GHC 8.8.4)
+resolver: lts-16.8

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 519764
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2019/7/15.yaml
-    sha256: 3f93a8081b0d3e6ee2b463886b1cc9f60403fae8a2eaeab4701b6e6150dfc98d
-  original: nightly-2019-07-15
+    size: 532379
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/8.yaml
+    sha256: 2ad3210d2ad35f3176005d68369a18e4d984517bfaa2caade76f28ed0b2e0521
+  original: lts-16.8


### PR DESCRIPTION
`nightly-2019-07-15` (GHC 8.6.5) has been overtaken by `lts-14.27`.