### PR TITLE
Update stack.yaml and CI script, for lts-16.12

### DIFF
--- a/.azure/azure-windows-template.yml
+++ b/.azure/azure-windows-template.yml
@@ -4,10 +4,8 @@ jobs:
     vmImage: ${{ parameters.vmImage }}
   strategy:
     matrix:
-# GHC 8.8.x below 8.8.4 excluded because broken on Windows 10 version 2004. See
-# https://downloads.haskell.org/~ghc/8.8.4/docs/html/users_guide/8.8.4-notes.html#highlights
-#     stack-def:
-#       BUILD: stack
+      stack-def:
+        BUILD: stack
       stack-ghc-8.4.4:
         BUILD: stack
         ARGS: "--stack-yaml stack-ghc-8.4.4.yaml"

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,2 +1,2 @@
-# For GHC 8.8.3 (none for GHC 8.8.4)
-resolver: lts-16.8
+# For GHC 8.8.4
+resolver: lts-16.12

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 532379
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/8.yaml
-    sha256: 2ad3210d2ad35f3176005d68369a18e4d984517bfaa2caade76f28ed0b2e0521
-  original: lts-16.8
+    size: 532377
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/12.yaml
+    sha256: f914cfa23fef85bdf895e300a8234d9d0edc2dbec67f4bc9c53f85867c50eab6
+  original: lts-16.12


### PR DESCRIPTION
`lts-16.12` is for GHC 8.8.4, which works on Windows 10 version 2004. GHC 8.8.4 is reintroduced into the CI for Windows.