### PR TITLE
Fix #1 Expose data constructor of StyleDoc

### DIFF
--- a/src/RIO/PrettyPrint.hs
+++ b/src/RIO/PrettyPrint.hs
@@ -24,7 +24,7 @@ module RIO.PrettyPrint
     , spacedBulletedList
     , debugBracket
       -- * Re-exports from "Text.PrettyPrint.Leijen.Extended"
-    , Pretty (..), StyleDoc, StyleAnn (..)
+    , Pretty (..), StyleDoc (..), StyleAnn (..)
     , nest, line, linebreak, group, softline, softbreak
     , align, hang, indent, encloseSep
     , (<+>)

--- a/src/Text/PrettyPrint/Leijen/Extended.hs
+++ b/src/Text/PrettyPrint/Leijen/Extended.hs
@@ -24,7 +24,7 @@ module Text.PrettyPrint.Leijen.Extended
   --
   -- See "System.Console.ANSI" for 'SGR' values to use beyond the colors
   -- provided.
-  StyleDoc, StyleAnn(..),
+  StyleDoc (..), StyleAnn(..),
   -- hDisplayAnsi,
   displayAnsi, displayPlain, renderDefault,
 


### PR DESCRIPTION
Also bumps the Azure CI to use the latest virtual machine images, as those specified no longer exist.

Also removes 'style' from the Azure CI matrix. GitHub now uses the custom `<include-fragment>` element on the 'releases' page, so the algorithm of getting the HTML and grepping it will not work. I will propose another pull request to move the CI to GitHub Actions and restore the use of Hlint when I do so.