### PR TITLE
Add `SimplePrettyApp` and `PrettyException`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,12 @@
 # Changelog for rio-prettyprint
 
+## 0.1.3.0
+
+* Add `SimplePrettyApp`, `mkSimplePrettyApp` and `runSimplePrettyApp`, which
+  facilitate the provision, and use, of a basic environment including pretty
+  printing functionality.
+* Add `PrettyException` representing pretty exceptions.
+
 ## 0.1.2.0
 
 * Expose data constructor of StyleDoc [#8](https://github.com/commercialhaskell/rio-prettyprint/pull/8)

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:        rio-prettyprint
-version:     0.1.2.0
+version:     0.1.3.0
 synopsis:    Pretty-printing for RIO
 category:    Development
 author:      Michael Snoyman

--- a/src/RIO/PrettyPrint/PrettyException.hs
+++ b/src/RIO/PrettyPrint/PrettyException.hs
@@ -1,0 +1,79 @@
+{-# LANGUAGE NoImplicitPrelude         #-}
+{-# LANGUAGE ExistentialQuantification #-}
+
+{-|
+This module provides a type representing pretty exceptions. It can be used as in
+the example below:
+
+@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main (main) where
+
+import RIO
+         ( Exception, Handler (..), IO, RIO, Show, SomeException (..), Typeable
+         , ($), catches, displayException, exitFailure, fromString, logError
+         , mempty, throwIO
+         )
+import RIO.PrettyPrint
+         ( Pretty (..), Style (..), (<+>), prettyError, prettyInfo, style )
+import RIO.PrettyPrint.PrettyException ( PrettyException (..) )
+import RIO.PrettyPrint.Simple ( SimplePrettyApp, runSimplePrettyApp )
+
+main :: IO ()
+main = runSimplePrettyApp 80 mempty (action `catches` handleExceptions)
+ where
+  action :: RIO SimplePrettyApp ()
+  action = do
+      prettyInfo "Running action!"
+      throwIO (PrettyException MyPrettyException)
+
+  handleExceptions :: [Handler (RIO SimplePrettyApp) ()]
+  handleExceptions =
+    [ Handler handlePrettyException
+    , Handler handleSomeException
+    ]
+
+  handlePrettyException :: PrettyException -> RIO SimplePrettyApp ()
+  handlePrettyException e = do
+    prettyError $ pretty e
+    exitFailure
+
+  handleSomeException :: SomeException -> RIO SimplePrettyApp ()
+  handleSomeException (SomeException e) = do
+    logError $ fromString $ displayException e
+    exitFailure
+
+data MyPrettyException
+  = MyPrettyException
+  deriving (Show, Typeable)
+
+instance Pretty MyPrettyException where
+  pretty MyPrettyException =
+    "My" <+> style Highlight "pretty" <+> "exception!"
+
+instance Exception MyPrettyException
+@
+-}
+module RIO.PrettyPrint.PrettyException
+  ( PrettyException (..)
+  ) where
+
+import RIO (Exception, Show (..), Typeable)
+import Text.PrettyPrint.Leijen.Extended (Pretty (..))
+
+-- | Type representing pretty exceptions.
+--
+-- @since 0.1.3.0
+data PrettyException
+  = forall e. (Exception e, Pretty e) => PrettyException e
+  deriving Typeable
+
+instance Show PrettyException where
+  show (PrettyException e) = show e
+
+instance Pretty PrettyException where
+  pretty (PrettyException e) = pretty e
+
+instance Exception PrettyException

--- a/src/RIO/PrettyPrint/Simple.hs
+++ b/src/RIO/PrettyPrint/Simple.hs
@@ -1,0 +1,98 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+{-|
+This module exports a 'SimplePrettyApp' type, for providing a basic environment
+including pretty printing functionality.
+-}
+module RIO.PrettyPrint.Simple
+  ( SimplePrettyApp
+  , mkSimplePrettyApp
+  , runSimplePrettyApp
+  ) where
+
+import System.Environment (lookupEnv)
+
+import RIO
+         ( Bool (..), HasLogFunc (..), Int, LogFunc, Maybe (..), MonadIO, RIO
+         , ($), (<$>), isJust, lens, liftIO, logOptionsHandle, maybe, pure
+         , runRIO, setLogUseColor, stderr, withLogFunc
+         )
+import RIO.Process
+         ( HasProcessContext (..), ProcessContext, mkDefaultProcessContext )
+
+import RIO.PrettyPrint (HasTerm (..))
+import RIO.PrettyPrint.StylesUpdate (HasStylesUpdate (..), StylesUpdate (..))
+
+-- | A simple, non-customizable environment type, which provides
+-- pretty printing functionality.
+--
+-- @since 0.1.3.0
+data SimplePrettyApp = SimplePrettyApp
+  { spaLogFunc :: !LogFunc
+  , spaProcessContext :: !ProcessContext
+  , spaUseColor :: !Bool
+  , spaTermWidth :: !Int
+  , spaStylesUpdate :: !StylesUpdate
+  }
+
+instance HasLogFunc SimplePrettyApp where
+  logFuncL = lens spaLogFunc (\x y -> x { spaLogFunc = y })
+
+instance HasProcessContext SimplePrettyApp where
+  processContextL = lens spaProcessContext (\x y -> x { spaProcessContext = y })
+
+instance HasStylesUpdate SimplePrettyApp where
+  stylesUpdateL = lens spaStylesUpdate (\x y -> x { spaStylesUpdate = y })
+
+instance HasTerm SimplePrettyApp where
+  useColorL = lens spaUseColor (\x y -> x { spaUseColor = y })
+  termWidthL = lens spaTermWidth (\x y -> x { spaTermWidth = y })
+
+-- | Constructor for 'SimplePrettyApp'. If 'ProcessContext' is not supplied
+-- 'mkDefaultProcessContext' will be used to create it.
+--
+-- @since 0.1.3.0
+mkSimplePrettyApp
+  :: MonadIO m
+  => LogFunc
+  -> Maybe ProcessContext
+  -> Bool
+     -- ^ Use color?
+  -> Int
+     -- ^ Terminal width
+  -> StylesUpdate
+  -> m SimplePrettyApp
+mkSimplePrettyApp logFunc mProcessContext useColor termWidth stylesUpdate = do
+  processContext <- maybe mkDefaultProcessContext pure mProcessContext
+  pure $ SimplePrettyApp
+    { spaLogFunc = logFunc
+    , spaProcessContext = processContext
+    , spaUseColor = useColor
+    , spaTermWidth = termWidth
+    , spaStylesUpdate = stylesUpdate
+    }
+
+-- | Run with a default configured @SimplePrettyApp@, consisting of:
+--
+-- * Logging to 'stderr'
+--
+-- * If the @RIO_VERBOSE@ environment variable is set, turns on verbose logging
+--
+-- * Default process context
+--
+-- * Logging using color
+--
+-- @since 0.1.3.0
+runSimplePrettyApp
+  :: MonadIO m
+  => Int
+     -- ^ Terminal width
+  -> StylesUpdate
+  -> RIO SimplePrettyApp a
+  -> m a
+runSimplePrettyApp termWidth stylesUpdate m = liftIO $ do
+  verbose <- isJust <$> lookupEnv "RIO_VERBOSE"
+  lo <- setLogUseColor True <$> logOptionsHandle stderr verbose
+  withLogFunc lo $ \lf -> do
+    simplePrettyApp <- mkSimplePrettyApp lf Nothing True termWidth stylesUpdate
+    runRIO simplePrettyApp m

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 532377
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/12.yaml
-    sha256: f914cfa23fef85bdf895e300a8234d9d0edc2dbec67f4bc9c53f85867c50eab6
-  original: lts-16.12
+    sha256: e5f56f619132209b826084cacd6374d7f0344cc88a9d1d305878190e4204ae1f
+    size: 619205
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/19/31.yaml
+  original: lts-19.31


### PR DESCRIPTION
This pull request proposes a `SimplePrettyApp` type with two related functions; like `SimpleApp` of the `RIO` package and its two related functions, but also supporting pretty printing functionality.

It also proposes a `PrettyException` type that represents pretty exceptions. That is, exceptions that are instances of `Pretty`. It includes Haddock documentation that illustrates how such pretty exceptions can be used.

On Hackage, the packages that depend on `rio-prettyprint` are `http-download`, `pantry` and `stack`. Stack will be able to make use of pretty exceptions; in fact, this pull request effectively moves some logic out of Stack's `master` branch into `rio-prettyprint`.

Tested by building and using the example code provided in the Haddock documentation.