### PR TITLE
Make StyleDoc an instance of Show

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,10 +13,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os:
+        # As of 27 November 2022, ubuntu-lastest corresponds to ubuntu-20.04.
+        # However, ubuntu-20.04 has package 'libc6 (2.31-0ubuntu9.7 and others)'
+        # and, from GHC 9.4.1, ghc-9.4.1-x86_64-fedora33-linux.tar.xz etc is
+        # built on Fedora 33, whuch comes with glibc version 2.32. Hence use
+        # ubuntu-22.04.
+        - ubuntu-22.04
+        - macos-latest
+        - windows-latest
         resolver:
-        - nightly-2022-11-03 # GHC 9.2.4
-        - lts-19.31 # GHC 9.0.2
+        - nightly-2022-11-26 # GHC 9.4.3
+        - lts-20.1 # GHC 9.2.5
+        - lts-19.33 # GHC 9.0.2
         - lts-18.28 # GHC 8.10.7
     steps:
     - name: Clone project

--- a/src/Text/PrettyPrint/Leijen/Extended.hs
+++ b/src/Text/PrettyPrint/Leijen/Extended.hs
@@ -173,7 +173,7 @@ instance Monoid StyleAnn where
 
 -- |A document annotated by a style
 newtype StyleDoc = StyleDoc { unStyleDoc :: Doc StyleAnn }
-  deriving IsString
+  deriving (IsString, Show)
 
 -- |An ANSI code(s) annotation.
 newtype AnsiAnn = AnsiAnn [SGR]

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,2 +1,2 @@
-# For GHC 9.0.2
-resolver: lts-19.31
+# For GHC 9.2.5
+resolver: lts-20.1

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    sha256: e5f56f619132209b826084cacd6374d7f0344cc88a9d1d305878190e4204ae1f
-    size: 619205
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/19/31.yaml
-  original: lts-19.31
+    sha256: b73b2b116143aea728c70e65c3239188998bac5bc3be56465813dacd74215dc5
+    size: 648424
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/1.yaml
+  original: lts-20.1


### PR DESCRIPTION
The motivation for this is that, with `PrettyException`, it can be useful sometimes for the data constructors of the exceptions to include values of type `StyleDoc`. However, `class (Typeable e, Show e) => Exception e where`. 

Also bumps `stack.yaml` to lts-20.1 (GHC 9.2.5).

Also updates CI to include GHC 9.4.3.