### PR TITLE
Change approach to PrettyException instance of Show

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,8 +1,10 @@
 # Changelog for rio-prettyprint
 
-## 0.2.0.0
+## 0.1.4.0
 
 * Add `string` and `mkNarrativeList`.
+* The `Show` instance of `PrettyException` is now derived. `displayException` is
+  now defined, as the `displayException` of the inner exception.
 
 ## 0.1.3.0
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:        rio-prettyprint
-version:     0.2.0.0
+version:     0.1.4.0
 synopsis:    Pretty-printing for RIO
 category:    Development
 author:      Michael Snoyman

--- a/src/RIO/PrettyPrint.hs
+++ b/src/RIO/PrettyPrint.hs
@@ -178,7 +178,7 @@ bulletedList = mconcat . intersperse line . map (("*" <+>) . align)
 -- @\"apple, ball and cat.\"@ (no serial comma) or @\"apple, ball, and cat.\"@
 -- (serial comma) from @[\"apple\", \"ball\", \"cat\"]@.
 --
--- @since 0.2.0.0
+-- @since 0.1.4.0
 mkNarrativeList :: Pretty a
                 => Maybe Style
                 -- ^ Style the items in the list?

--- a/src/RIO/PrettyPrint/PrettyException.hs
+++ b/src/RIO/PrettyPrint/PrettyException.hs
@@ -1,79 +1,77 @@
 {-# LANGUAGE NoImplicitPrelude         #-}
 {-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE StandaloneDeriving        #-}
 
-{-|
-This module provides a type representing pretty exceptions. It can be used as in
-the example below:
-
-@
-{-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE OverloadedStrings #-}
-
-module Main (main) where
-
-import RIO
-         ( Exception, Handler (..), IO, RIO, Show, SomeException (..), Typeable
-         , ($), catches, displayException, exitFailure, fromString, logError
-         , mempty, throwIO
-         )
-import RIO.PrettyPrint
-         ( Pretty (..), Style (..), (<+>), prettyError, prettyInfo, style )
-import RIO.PrettyPrint.PrettyException ( PrettyException (..) )
-import RIO.PrettyPrint.Simple ( SimplePrettyApp, runSimplePrettyApp )
-
-main :: IO ()
-main = runSimplePrettyApp 80 mempty (action `catches` handleExceptions)
- where
-  action :: RIO SimplePrettyApp ()
-  action = do
-      prettyInfo "Running action!"
-      throwIO (PrettyException MyPrettyException)
-
-  handleExceptions :: [Handler (RIO SimplePrettyApp) ()]
-  handleExceptions =
-    [ Handler handlePrettyException
-    , Handler handleSomeException
-    ]
-
-  handlePrettyException :: PrettyException -> RIO SimplePrettyApp ()
-  handlePrettyException e = do
-    prettyError $ pretty e
-    exitFailure
-
-  handleSomeException :: SomeException -> RIO SimplePrettyApp ()
-  handleSomeException (SomeException e) = do
-    logError $ fromString $ displayException e
-    exitFailure
-
-data MyPrettyException
-  = MyPrettyException
-  deriving (Show, Typeable)
-
-instance Pretty MyPrettyException where
-  pretty MyPrettyException =
-    "My" <+> style Highlight "pretty" <+> "exception!"
-
-instance Exception MyPrettyException
-@
--}
+-- | This module provides a type representing pretty exceptions. It can be used
+-- as in the example below:
+--
+-- > {-# LANGUAGE NoImplicitPrelude #-}
+-- > {-# LANGUAGE OverloadedStrings #-}
+-- >
+-- > module Main (main) where
+-- >
+-- > import RIO
+-- >          ( Exception, Handler (..), IO, RIO, Show, SomeException (..), Typeable
+-- >          , ($), catches, displayException, exitFailure, fromString, logError
+-- >          , mempty, throwIO
+-- >          )
+-- > import RIO.PrettyPrint
+-- >          ( Pretty (..), Style (..), (<+>), prettyError, prettyInfo, style )
+-- > import RIO.PrettyPrint.PrettyException ( PrettyException (..) )
+-- > import RIO.PrettyPrint.Simple ( SimplePrettyApp, runSimplePrettyApp )
+-- >
+-- > main :: IO ()
+-- > main = runSimplePrettyApp 80 mempty (action `catches` handleExceptions)
+-- >  where
+-- >   action :: RIO SimplePrettyApp ()
+-- >   action = do
+-- >       prettyInfo "Running action!"
+-- >       throwIO (PrettyException MyPrettyException)
+-- >
+-- >  handleExceptions :: [Handler (RIO SimplePrettyApp) ()]
+-- >  handleExceptions =
+-- >    [ Handler handlePrettyException
+-- >    , Handler handleSomeException
+-- >    ]
+-- >
+-- >  handlePrettyException :: PrettyException -> RIO SimplePrettyApp ()
+-- >  handlePrettyException e = do
+-- >    prettyError $ pretty e
+-- >    exitFailure
+-- >
+-- >  handleSomeException :: SomeException -> RIO SimplePrettyApp ()
+-- >  handleSomeException (SomeException e) = do
+-- >    logError $ fromString $ displayException e
+-- >    exitFailure
+-- >
+-- > data MyPrettyException
+-- >   = MyPrettyException
+-- >   deriving (Show, Typeable)
+-- >
+-- > instance Pretty MyPrettyException where
+-- >   pretty MyPrettyException =
+-- >     "My" <+> style Highlight "pretty" <+> "exception!"
+-- >
+-- > instance Exception MyPrettyException
+--
 module RIO.PrettyPrint.PrettyException
   ( PrettyException (..)
   ) where
 
-import RIO (Exception, Show (..), Typeable)
+import RIO (Exception (..), Show, Typeable)
 import Text.PrettyPrint.Leijen.Extended (Pretty (..))
 
 -- | Type representing pretty exceptions.
 --
--- @since 0.1.3.0
+-- @since 0.1.4.0
 data PrettyException
   = forall e. (Exception e, Pretty e) => PrettyException e
   deriving Typeable
 
-instance Show PrettyException where
-  show (PrettyException e) = show e
+deriving instance Show PrettyException
 
 instance Pretty PrettyException where
   pretty (PrettyException e) = pretty e
 
-instance Exception PrettyException
+instance Exception PrettyException where
+  displayException (PrettyException e) = displayException e

--- a/src/Text/PrettyPrint/Leijen/Extended.hs
+++ b/src/Text/PrettyPrint/Leijen/Extended.hs
@@ -391,7 +391,7 @@ brackets = StyleDoc . P.brackets . unStyleDoc
 -- newline characters and @char@ for all other characters. It is used whenever
 -- the text contains newline characters.
 --
--- @since 0.2.0.0
+-- @since 0.1.4.0
 string :: String -> StyleDoc
 string "" = mempty
 string ('\n':s) = line <> string s

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    sha256: e5f56f619132209b826084cacd6374d7f0344cc88a9d1d305878190e4204ae1f
-    size: 619205
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/19/31.yaml
-  original: lts-19.31
+    sha256: b73b2b116143aea728c70e65c3239188998bac5bc3be56465813dacd74215dc5
+    size: 648424
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/1.yaml
+  original: lts-20.1


### PR DESCRIPTION
This also corrects the example code block in the Haddock documentation for `RIO.PrettyPrint.PrettyException` (Bird tracks rather than `@...@`).

This assumes that the change to `show` means that PVP requires a major version bump.

The motivation for this change is that Simon Hengel recently explained to me that there was an unwritten rule that instances of `Show` should behave like derived instances of `Show` and that I should prefer the `displayException` function promised by the `Exception` class to `show`.

Tested by building Stack with this as a dependency. (The master branch version of Stack now uses `displayException` consistently.)