### PR TITLE
Add `string` and `mkNarrativeList`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,10 +13,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os:
+        # As of 27 November 2022, ubuntu-lastest corresponds to ubuntu-20.04.
+        # However, ubuntu-20.04 has package 'libc6 (2.31-0ubuntu9.7 and others)'
+        # and, from GHC 9.4.1, ghc-9.4.1-x86_64-fedora33-linux.tar.xz etc is
+        # built on Fedora 33, whuch comes with glibc version 2.32. Hence use
+        # ubuntu-22.04.
+        - ubuntu-22.04
+        - macos-latest
+        - windows-latest
         resolver:
-        - nightly-2022-11-03 # GHC 9.2.4
-        - lts-19.31 # GHC 9.0.2
+        - nightly-2022-11-26 # GHC 9.4.3
+        - lts-20.1 # GHC 9.2.5
+        - lts-19.33 # GHC 9.0.2
         - lts-18.28 # GHC 8.10.7
     steps:
     - name: Clone project

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for rio-prettyprint
 
+## 0.2.0.0
+
+* Add `string` and `mkNarrativeList`.
+
 ## 0.1.3.0
 
 * Add `SimplePrettyApp`, `mkSimplePrettyApp` and `runSimplePrettyApp`, which

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:        rio-prettyprint
-version:     0.1.3.0
+version:     0.2.0.0
 synopsis:    Pretty-printing for RIO
 category:    Development
 author:      Michael Snoyman

--- a/src/Text/PrettyPrint/Leijen/Extended.hs
+++ b/src/Text/PrettyPrint/Leijen/Extended.hs
@@ -86,11 +86,12 @@ module Text.PrettyPrint.Leijen.Extended
   -- @
 
   -- ** Primitive type documents
-  -- Entirely omitted:
+  -- Omitted compared to the original:
   --
   -- @
-  -- string, int, integer, float, double, rational, bool,
+  -- int, integer, float, double, rational, bool,
   -- @
+  string,
 
   -- ** Semantic annotations
   annotate, noAnnotate, styleAnn
@@ -385,6 +386,17 @@ squotes = StyleDoc . P.squotes . unStyleDoc
 
 brackets :: StyleDoc -> StyleDoc
 brackets = StyleDoc . P.brackets . unStyleDoc
+
+-- | The document @string s@ concatenates all characters in @s@ using @line@ for
+-- newline characters and @char@ for all other characters. It is used whenever
+-- the text contains newline characters.
+--
+-- @since 0.2.0.0
+string :: String -> StyleDoc
+string "" = mempty
+string ('\n':s) = line <> string s
+string s        = let (xs, ys) = span (/='\n') s
+                  in  fromString xs <> string ys
 
 annotate :: StyleAnn -> StyleDoc -> StyleDoc
 annotate a = StyleDoc . P.annotate a . unStyleDoc

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,2 +1,2 @@
-# For GHC 9.0.2
-resolver: lts-19.31
+# For GHC 9.2.5
+resolver: lts-20.1


### PR DESCRIPTION
`string` follows `Text.PrettyPrint.Annotated.Leijen.string`.

The motivation for introducing these functions is that the master branch version of Stack makes, or will make, use of both of them and it would be convenient to push them down to `rio-prettyprint`.