### PR TITLE
Fix #18 Update CI for GHC releases

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,19 +14,14 @@ jobs:
       fail-fast: false
       matrix:
         os:
-        # As of 27 November 2022, ubuntu-lastest corresponds to ubuntu-20.04.
-        # However, ubuntu-20.04 has package 'libc6 (2.31-0ubuntu9.7 and others)'
-        # and, from GHC 9.4.1, ghc-9.4.1-x86_64-fedora33-linux.tar.xz etc is
-        # built on Fedora 33, whuch comes with glibc version 2.32. Hence use
-        # ubuntu-22.04.
-        - ubuntu-22.04
+        - ubuntu-latest
         - macos-latest
         - windows-latest
         resolver:
-        - nightly-2022-11-26 # GHC 9.4.3
-        - lts-20.1 # GHC 9.2.5
+        - nightly-2023-08-29 # GHC 9.6.2
+        - lts-21.9 # GHC 9.4.6
+        - lts-20.26 # GHC 9.2.8
         - lts-19.33 # GHC 9.0.2
-        - lts-18.28 # GHC 8.10.7
     steps:
     - name: Clone project
       uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /.stack-work/
-/rio-prettyprint.cabal
 *~

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015-2019, Stack contributors
+Copyright (c) 2015-2023, Stack contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/rio-prettyprint.cabal
+++ b/rio-prettyprint.cabal
@@ -1,0 +1,50 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.35.4.
+--
+-- see: https://github.com/sol/hpack
+
+name:           rio-prettyprint
+version:        0.1.4.0
+synopsis:       Pretty-printing for RIO
+description:    Combine RIO's log capabilities with pretty printing
+category:       Development
+homepage:       https://github.com/commercialhaskell/rio-prettyprint#readme
+bug-reports:    https://github.com/commercialhaskell/rio-prettyprint/issues
+author:         Michael Snoyman
+maintainer:     michael@snoyman.com
+copyright:      2018-2019 FP Complete
+license:        BSD3
+license-file:   LICENSE
+build-type:     Simple
+
+source-repository head
+  type: git
+  location: https://github.com/commercialhaskell/rio-prettyprint
+
+library
+  exposed-modules:
+      RIO.PrettyPrint
+      RIO.PrettyPrint.DefaultStyles
+      RIO.PrettyPrint.PrettyException
+      RIO.PrettyPrint.Simple
+      RIO.PrettyPrint.StylesUpdate
+      RIO.PrettyPrint.Types
+      Text.PrettyPrint.Leijen.Extended
+  other-modules:
+      Paths_rio_prettyprint
+  hs-source-dirs:
+      src/
+  build-depends:
+      Cabal
+    , aeson
+    , annotated-wl-pprint
+    , ansi-terminal >=0.9
+    , array
+    , base >=4.10 && <5
+    , colour
+    , mtl
+    , path
+    , rio
+    , text
+  default-language: Haskell2010

--- a/stack-ghc-8.4.4.yaml
+++ b/stack-ghc-8.4.4.yaml
@@ -1,4 +1,0 @@
-# Last for GHC 8.4.x
-resolver: lts-12.14
-extra-deps:
-- ansi-terminal-0.10.3

--- a/stack-ghc-8.6.5.yaml
+++ b/stack-ghc-8.6.5.yaml
@@ -1,2 +1,0 @@
-# Last for GHC 8.6.x
-resolver: lts-14.27

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,2 +1,2 @@
-# For GHC 9.2.5
-resolver: lts-20.1
+# For GHC 9.4.6
+resolver: lts-21.9

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    sha256: b73b2b116143aea728c70e65c3239188998bac5bc3be56465813dacd74215dc5
-    size: 648424
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/1.yaml
-  original: lts-20.1
+    sha256: 2fc12a405ab6f7eac73eb11a0ca5ccca0e956bd2848db780c140b7406ff9ebb5
+    size: 640035
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/21/9.yaml
+  original: lts-21.9


### PR DESCRIPTION
Also commits the Cabal file.

Also updates the years in the LICENSE.