### PR TITLE
Add Arch and OS instances of Pretty

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for rio-prettyprint
 
+## 0.1.8.0
+
+* Add `Arch` and `OS` instances of `Pretty`.
+
 ## 0.1.7.0
 
 * Add `prettyThrowIO` and `prettyThrowM`, to throw an exception as a
@@ -17,12 +21,12 @@
 
 ## 0.1.5.0
 
-* Add `Pretty` instances for `SomeBase Dir` and `SomeBase File`.
+* Add `SomeBase Dir` and `SomeBase File` instances of `Pretty`.
 
 ## 0.1.4.0
 
 * Add `string` and `mkNarrativeList`.
-* The `Show` instance of `PrettyException` is now derived. `displayException` is
+* The `PrettyException` instance of `Show` is now derived. `displayException` is
   now defined, as the `displayException` of the inner exception.
 
 ## 0.1.3.0

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:        rio-prettyprint
-version:     0.1.7.0
+version:     0.1.8.0
 synopsis:    Pretty-printing for RIO
 description: Combine RIO's log capabilities with pretty printing
 category:    Development

--- a/rio-prettyprint.cabal
+++ b/rio-prettyprint.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.5.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
 name:           rio-prettyprint
-version:        0.1.7.0
+version:        0.1.8.0
 synopsis:       Pretty-printing for RIO
 description:    Combine RIO's log capabilities with pretty printing
 category:       Development

--- a/src/Text/PrettyPrint/Leijen/Extended.hs
+++ b/src/Text/PrettyPrint/Leijen/Extended.hs
@@ -20,7 +20,7 @@ module Text.PrettyPrint.Leijen.Extended
 
     -- * Documents annotated by a style
   , StyleDoc (..)
-  , StyleAnn(..)
+  , StyleAnn (..)
   , displayAnsi
   , displayPlain
   , renderDefault
@@ -156,7 +156,9 @@ import           Control.Monad.Reader ( local, runReader )
 import           Data.Array.IArray ( (!), (//) )
 import qualified Data.Text as T
 import           Distribution.ModuleName ( ModuleName )
+import           Distribution.System ( Arch (..), OS (..) )
 import qualified Distribution.Text ( display )
+import           Distribution.Utils.Generic ( lowercase )
 import           Path ( Dir, File, Path, SomeBase, prjSomeBase, toFilePath )
 import           RIO
 import qualified RIO.Map as M
@@ -208,6 +210,14 @@ instance Pretty (SomeBase Dir) where
 
 instance Pretty ModuleName where
   pretty = StyleDoc . fromString . Distribution.Text.display
+
+instance Pretty Arch where
+  pretty (OtherArch name) = fromString name
+  pretty other = fromString $ lowercase $ show other
+
+instance Pretty OS where
+  pretty (OtherOS name) = fromString name
+  pretty other = fromString $ lowercase $ show other
 
 --------------------------------------------------------------------------------
 -- Style Doc


### PR DESCRIPTION
The motivation is that the Stack project can make use of the instances and this will avoid orphan instances.

`rio-prettyprint` already has a dependency on the `Cabal` package and, consequently, the `Cabal-syntax` package.

The instances mirror those of `Cabal-syntax` for its `Distribution.Pretty.Pretty` class. That class is  based on the `pretty` package's `Text.PrettyPrint.Doc` type (a `newtype` wrapper around its `Text.PrettyPrint.Annotated.HughesPJ.Doc` type).

The `rio-prettyprint` package's `StyleDoc` type is based on the `annotated-wl-pprint` package's `Text.PrettyPrint.Annotated.Leijen.Doc a` type. 